### PR TITLE
Fix to prevent mem leak.

### DIFF
--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -83,6 +83,7 @@ static bool is_local_var_matching(zend_execute_data* execute_data, const sp_disa
     } else {
       zend_string const* const var_value_str = sp_zval_to_zend_string(var_value);
       bool match = sp_match_value(var_value_str, config_node->value, config_node->r_value);
+      zend_string_release(var_value_str);
 
       if (true == match) {
         return true;
@@ -112,7 +113,7 @@ static bool is_param_matching(zend_execute_data* execute_data,
     * and they can only take a single argument, but PHP considers them
     * differently than functions arguments. */
     *arg_name = builtin_param_name;
-    *arg_value_str = builtin_param;
+    *arg_value_str = zend_string_copy(builtin_param);
     return sp_match_value(builtin_param, config_node->value,
                           config_node->r_value);
   }
@@ -367,6 +368,10 @@ static void should_disable(zend_execute_data* execute_data,
     }
 
   next:
+    if (arg_value_str) {
+      zend_string_release(arg_value_str);
+      arg_value_str = NULL;
+    }
     config = config->next;
   }
 }
@@ -459,6 +464,10 @@ static void should_drop_on_ret(const zval* return_value,
         return;
       }
       sp_log_disable_ret(complete_function_path, ret_value_str, config_node);
+    }
+    if (ret_value_str) {
+      zend_string_release(ret_value_str);
+      ret_value_str = NULL;
     }
   next:
     config = config->next;

--- a/src/sp_utils.c
+++ b/src/sp_utils.c
@@ -235,21 +235,21 @@ static char* zend_string_to_char(const zend_string* zs) {
 const zend_string* sp_zval_to_zend_string(const zval* zv) {
   switch (Z_TYPE_P(zv)) {
     case IS_LONG: {
-      char* msg;
+      char* msg = NULL;
       spprintf(&msg, 0, ZEND_LONG_FMT, Z_LVAL_P(zv));
       zend_string* zs = zend_string_init(msg, strlen(msg), 0);
       efree(msg);
       return zs;
     }
     case IS_DOUBLE: {
-      char* msg;
+      char* msg = NULL;
       spprintf(&msg, 0, "%f", Z_DVAL_P(zv));
       zend_string* zs = zend_string_init(msg, strlen(msg), 0);
       efree(msg);
       return zs;
     }
     case IS_STRING: {
-      return Z_STR_P(zv);
+      return zend_string_copy(Z_STR_P(zv));
     }
     case IS_FALSE:
       return zend_string_init(ZEND_STRL("FALSE"), 0);
@@ -334,11 +334,11 @@ void sp_log_disable_ret(const char* restrict path,
     sp_log_request(dump, config_node->textual_representation);
   }
   if (ret_value) {
-    zend_string *ret_value_dup = zend_string_init(ZSTR_VAL(ret_value), ZSTR_LEN(ret_value), 0);
-    ret_value_dup = php_raw_url_encode(ZSTR_VAL(ret_value_dup), ZSTR_LEN(ret_value_dup));
+    zend_string *ret_value_dup = php_raw_url_encode(ZSTR_VAL(ret_value), ZSTR_LEN(ret_value));
     char_repr = zend_string_to_char(ret_value_dup);
     size_t max_len = MIN(ZSTR_LEN(ret_value_dup), (size_t)SPCFG(log_max_len));
     char_repr[max_len] = '\0';
+    zend_string_release(ret_value_dup);
   }
   if (alias) {
     sp_log_auto(
@@ -368,11 +368,14 @@ bool sp_match_array_key(const zval* zv, const zend_string* to_match, const sp_re
       char* idx_str = NULL;
       spprintf(&idx_str, 0, ZEND_ULONG_FMT, idx);
       zend_string* tmp = zend_string_init(idx_str, strlen(idx_str), 0);
-      if (sp_match_value(tmp, to_match, rx)) {
-        efree(idx_str);
+      bool matched = sp_match_value(tmp, to_match, rx);
+  
+      efree(idx_str);
+      zend_string_release(tmp);
+
+      if (matched) {
         return true;
       }
-      efree(idx_str);
     }
   }
   ZEND_HASH_FOREACH_END();

--- a/src/sp_var_value.c
+++ b/src/sp_var_value.c
@@ -119,8 +119,10 @@ static zval *get_array_value(zend_execute_data *ed, const zval *const zvalue,
 
   if (Z_TYPE_P(zvalue) == IS_ARRAY) {
     const zend_string *const idx = sp_zval_to_zend_string(idx_value);
-    return get_entry_hashtable(Z_ARRVAL_P(zvalue), ZSTR_VAL(idx),
+    zval *rv = get_entry_hashtable(Z_ARRVAL_P(zvalue), ZSTR_VAL(idx),
                                ZSTR_LEN(idx));
+    zend_string_release(idx);
+    return rv;
   }
 
   return NULL;


### PR DESCRIPTION
POC to reproduce:
```PHP
<?php
function log_mem() {
    echo memory_get_usage() . "\n";
}

log_mem();

for ($i = 0; $i < 5000; $i++) {
    $c = curl_init('http://127.0.0.1/');

    curl_setopt($c, CURLOPT_RETURNTRANSFER, 1);
    curl_setopt($c, CURLOPT_RETURNTRANSFER, 1);
    curl_setopt($c, CURLOPT_RETURNTRANSFER, 1);
    curl_setopt($c, CURLOPT_RETURNTRANSFER, 1);

    $rv = curl_exec($c);
    curl_close($c);
    unset($rv);
}
log_mem();
```

sp.rules:
```
set TEST_REAL_ROOT_RX "^(/var/www)?/(html)/(include|modules|src|vendor|clients|data|install|service|soap)/([^\\./][^/]*/)*[^\\./][^/]*\\.php$";
set TEST_FORBID_RX "^(/var/www/html)?/(custom|cache|upload)/";
sp.harden_random.enable();
sp.wrappers_whitelist.list("file,php,phar,data,http,https");
sp.wrappers_whitelist.php_list("stdout,stdin,stderr,memory,input,temp,output,fd");
sp.eval_blacklist.list("exec,system,shell_exec,pcntl_exec,unserialize,eval,ioctl,passthru,popen,proc_open");
sp.disable_function.function("putenv").param("assignment").value_r("^LD_").drop();
sp.disable_function.function("putenv").param("assignment").value("PATH").drop();
sp.disable_function.function("putenv").param("assignment").value_r("^GCONV_").drop();
sp.disable_function.function("curl_setopt").param("option").value("32").drop().alias("Please don't set CURLOPT_SSLVERSION.");
sp.disable_function.function("curl_setopt").param("option").value("84").drop().alias("Please don't set CURLOPT_HTTP_VERSION.");
sp.disable_function.function("curl_setopt").param("option").value("56").drop().alias("Please don't set CURLOPT_PROGRESSFUNCTION.");
sp.disable_function.function("curl_setopt").param("option").value("79").drop().alias("Please don't set CURLOPT_HEADERFUNCTION.");
sp.disable_function.function("curl_setopt").param("option").value("12").drop().alias("Please don't set CURLOPT_READFUNCTION.");
sp.disable_function.function("curl_setopt").param("option").value("11").drop().alias("Please don't set CURLOPT_WRITEFUNCTION.");
sp.disable_function.function("curl_setopt").param("option").value("219").drop().alias("Please don't set CURLOPT_XFERINFOFUNCTION.");
sp.disable_function.function("curl_setopt").param("option").value("96").drop().alias("Please don't set CURLOPT_CAPATH.");
sp.disable_function.function("curl_setopt").param("option").value("65").drop().alias("Please don't set CURLOPT_CAINFO.");
sp.disable_function.function("curl_setopt").param("option").value("41").drop().alias("Please don't set CURLOPT_VERBOSE.");
sp.disable_function.function("curl_setopt").param("option").value("216").drop().alias("Please don't set CURLOPT_SSL_OPTIONS.");
sp.disable_function.function("curl_setopt").param("option").value("221").drop().alias("Please don't set CURLOPT_DNS_INTERFACE.");
sp.disable_function.function("curl_setopt").param("option").value("222").drop().alias("Please don't set CURLOPT_DNS_LOCAL_IP4.");
sp.disable_function.function("curl_setopt").param("option").value("223").drop().alias("Please don't set CURLOPT_DNS_LOCAL_IP6.");
sp.disable_function.function("curl_setopt").param("option").value("77").drop().alias("Please don't set CURLOPT_EGDSOCKET.");
sp.disable_function.function("curl_setopt").param("option").value("83").drop().alias("Please don't set CURLOPT_SSL_CIPHER_LIST.");
sp.disable_function.function("curl_setopt").param("option").value("276").drop().alias("Please don't set CURLOPT_TLS13_CIPHERS.");
sp.disable_function.function("curl_setopt").param("option").value("231").drop().alias("Please don't set CURLOPT_UNIX_SOCKET_PATH.");
sp.disable_function.function("curl_setopt").filename_r(TEST_FORBID_RX).param("option").value("64").drop().alias("Please don't set CURLOPT_SSL_VERIFYPEER.");
sp.disable_function.function("curl_setopt").filename_r(TEST_FORBID_RX).param("option").value("81").drop().alias("Please don't set CURLOPT_SSL_VERIFYHOST.");
sp.disable_function.function("curl_setopt").filename_r(TEST_FORBID_RX).param("option").value("3").drop().alias("Please don't set CURLOPT_PORT.");
sp.disable_function.function("curl_setopt").filename_r(TEST_FORBID_RX).param("option").value("43").drop().alias("Please don't set CURLOPT_NOPROGRESS.");
sp.disable_function.function("curl_setopt").param("value").value_r("file://").drop().alias("file:// protocol is disabled");
sp.disable_function.function("curl_init").param("url").value_r("file://").drop().alias("file:// protocol is disabled");
sp.disable_function.function("eval").filename_r(TEST_REAL_ROOT_RX).allow();
sp.disable_function.function("eval").filename_r(TEST_FORBID_RX).drop();
sp.disable_function.function("eval").allow();
sp.disable_function.function("ioctl").filename_r(TEST_REAL_ROOT_RX).allow();
sp.disable_function.function("ioctl").drop();
sp.disable_function.function("exec").filename_r(TEST_REAL_ROOT_RX).allow();
sp.disable_function.function("exec").filename_r("^/usr/local/bin/").allow();
sp.disable_function.function("exec").drop();
sp.disable_function.function("system").drop();
sp.disable_function.function("shell_exec").drop();
sp.disable_function.function("pcntl_exec").filename_r("^/usr/local/bin/").allow();
sp.disable_function.function("pcntl_exec").drop();
sp.disable_function.function("passthru").filename_r(TEST_REAL_ROOT_RX).allow();
sp.disable_function.function("passthru").filename_r(TEST_FORBID_RX).drop();
sp.disable_function.function("passthru").allow();
sp.disable_function.function("popen").drop();
sp.disable_function.function_r("^ZipArchive::").filename_r(TEST_REAL_ROOT_RX).allow();
sp.disable_function.function_r("^ZipArchive::").drop();
sp.disable_function.function_r("^Archive_Tar::").drop();
sp.ini_protection.disable();
```